### PR TITLE
Fixed typo

### DIFF
--- a/inc/ResetPassword.php
+++ b/inc/ResetPassword.php
@@ -44,7 +44,7 @@ class ResetPassword extends SectionBase
         list($valid, $errors) = $form->validate();
 
         if (!empty($errors)) {
-            foreach ($error as $k => $err) {
+            foreach ($errors as $k => $err) {
                 $this->addError("validiation_{$k}", $err);
             }
 


### PR DESCRIPTION
There's a typo on the error variable that causes some PHP errors
