### PR TITLE
#13 - Fix password saving

### DIFF
--- a/inc/Account.php
+++ b/inc/Account.php
@@ -209,6 +209,10 @@ class Account extends SectionBase
             } else {
                 $this->addError('pass_error', __('Could not update password.', FE_ACCOUNTS_TD));
             }
+        } else {
+            if (isset($user->data->user_pass)) {
+                unset($user->data->user_pass);
+            }
         }
 
         // other plugins can hook in here and modify things to save.


### PR DESCRIPTION
https://github.com/chrisguitarguy/Front-End-Accounts/blob/master/inc/Account.php#L188

Calling `wp_get_current_user()` here feed the `$user` variable with all user table fields, including `user_pass` as a hashed string. 
If no password is filled by the user on the profile page, the `$user` object is directly passed to `wp_update_user()` with the hashed string as user password. This hash then gets hashed again: https://github.com/WordPress/WordPress/blob/master/wp-includes/user.php#L2155
And thus change the user password.

And so on each time profile is saved.
